### PR TITLE
static+shared build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,14 +403,14 @@ target_include_directories(${PROJECT_NAME}
 
 # Allow to build static and shared libraries at the same time
 if (BUILD_STATIC_LIBS)
-    set(ORIGINAL_STATIC_LIB_NAME ${PROJECT_NAME}-static)
-    add_library(${ORIGINAL_STATIC_LIB_NAME} STATIC
+    set(STATIC_LIB ${PROJECT_NAME}-static)
+    add_library(${STATIC_LIB} STATIC
         ${JSON_C_SOURCES}
         ${JSON_C_HEADERS}
     )
 
     # rename the static library
-    set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES
+    set_target_properties(${STATIC_LIB} PROPERTIES
         OUTPUT_NAME ${PROJECT_NAME}
     )
     list(APPEND CMAKE_TARGETS ${STATIC_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,7 @@ add_library(${PROJECT_NAME}
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VERSION 5.0.0
     SOVERSION 5)
-
+list(APPEND CMAKE_TARGETS ${PROJECT_NAME})
 # If json-c is used as subroject it set to target correct interface -I flags and allow
 # to build external target without extra include_directories(...)
 target_include_directories(${PROJECT_NAME}
@@ -413,6 +413,7 @@ if (BUILD_STATIC_LIBS)
     set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES
         OUTPUT_NAME ${PROJECT_NAME}
     )
+    list(APPEND CMAKE_TARGETS ${STATIC_LIB})
 endif ()
 
 # Always create new install dirs with 0755 permissions, regardless of umask
@@ -426,7 +427,7 @@ set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
 	WORLD_EXECUTE
    )
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${CMAKE_TARGETS}
     EXPORT ${PROJECT_NAME}-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cmake-configure
+++ b/cmake-configure
@@ -65,7 +65,7 @@ while [ $# -gt 0 ] ; do
 		FLAGS+=(-DBUILD_SHARED_LIBS=ON)
 		;;
 	--enable-static)
-		FLAGS+=(-DBUILD_SHARED_LIBS=OFF)
+		FLAGS+=(-DBUILD_STATIC_LIBS=ON)
 		;;
 	--disable-Bsymbolic)
 		FLAGS+=(-DDISABLE_BSYMBOLIC=ON)


### PR DESCRIPTION
This pull request fixes the static+shared build and improves the CMake build script by adding a list for the build targets, which can be appended conditionally. It also adds a minor fix to cmake-configure wrapper script.

re: https://github.com/json-c/json-c/pull/595